### PR TITLE
Fix bug with options in DateTimeField

### DIFF
--- a/src/FieldType/DateTime/DateTimeField.php
+++ b/src/FieldType/DateTime/DateTimeField.php
@@ -34,11 +34,12 @@ class DateTimeField extends FieldType
             $options = $this->formOptions($sectionEntity);
 
             // Default values
-            if (empty($options)) {
-                $options = [
-                    'format' => DateTimeType::HTML5_FORMAT,
-                    'data' => 'now'
-                ];
+            if (!isset($options['format'])) {
+                $options['format'] = DateTimeType::HTML5_FORMAT;
+            }
+
+            if (!isset($options['data'])) {
+                $options['data'] = 'now';
             }
 
             // As a config value, pass the date time argument

--- a/test/unit/FieldType/DateTime/DateTimeFieldTest.php
+++ b/test/unit/FieldType/DateTime/DateTimeFieldTest.php
@@ -38,7 +38,13 @@ class DateTimeFieldTest extends TestCase
                     [
                         'name' => 'sexyname',
                         'handle' => 'lovehandles',
-                        'form' => ['all' => ['data' => '2015-12-25']]
+                        'form' => [
+                            'all' => [
+                                'label' => 'a label',
+                                'format' => DateTimeType::HTML5_FORMAT,
+                                'data' => '2015-12-25'
+                            ]
+                        ]
                     ]
             ]
         );
@@ -52,8 +58,50 @@ class DateTimeFieldTest extends TestCase
             ->with(
                 (string)$dateTimeField->getConfig()->getHandle(),
                 DateTimeType::class,
-                ['data'=>new \DateTime('2015-12-25')]
+                [
+                    'label' => 'a label',
+                    'format' => DateTimeType::HTML5_FORMAT,
+                    'data'=>new \DateTime('2015-12-25')
+                ]
             )
+            ->andReturn($formBuilder);
+
+        $dateTimeField->addToForm($formBuilder, $section, $sectionEntity, $sectionManager, $readSection);
+
+        $this->assertInstanceOf(DateTimeField::class, $dateTimeField);
+        $this->assertEquals($dateTimeField->getConfig(), $config);
+    }
+
+    /**
+     * @test
+     * @covers ::addToForm
+     */
+    public function it_adds_to_form_even_if_no_format_or_data_key_in_config()
+    {
+        $formBuilder = M::mock(FormBuilderInterface::class);
+        $section = M::mock(SectionInterface::class);
+        $sectionEntity = M::mock(FieldType::class);
+        $sectionManager = M::mock(SectionManagerInterface::class);
+        $readSection = M::mock(ReadSectionInterface::class);
+
+        $dateTimeField = new DateTimeField();
+        $config = FieldConfig::fromArray(
+            [
+                'field' =>
+                    [
+                        'name' => 'sexyname',
+                        'handle' => 'lovehandles',
+                        'form' => ['all' => ['label' => 'a label']]
+                    ]
+            ]
+        );
+        $dateTimeField->setConfig($config);
+        $sectionEntity->shouldReceive('getId')
+            ->once()
+            ->andReturn(4);
+
+        $formBuilder->shouldReceive('add')
+            ->once()
             ->andReturn($formBuilder);
 
         $dateTimeField->addToForm($formBuilder, $section, $sectionEntity, $sectionManager, $readSection);


### PR DESCRIPTION
The $options array was checked on emptiness. If so, the format and data keys were filled.
However, if $options contained a label, then the format and data keys would not be filled and the application would crash.
Now both format and data are checked specifically and filled if needed.