### PR TITLE
Add possibility to use field alias in relationship

### DIFF
--- a/src/FieldType/Relationship/Relationship.php
+++ b/src/FieldType/Relationship/Relationship.php
@@ -190,7 +190,7 @@ class Relationship extends FieldType
             ->getConfig()
             ->getFullyQualifiedClassName();
 
-        $toHandle = $fieldConfig['field']['to'];
+        $toHandle = $fieldConfig['field']['as'] ?? $fieldConfig['field']['to'];
         $selectedEntity = $sectionEntity->{'get' . ucfirst($toHandle)}();
 
         try {
@@ -235,7 +235,7 @@ class Relationship extends FieldType
             ->getConfig()
             ->getFullyQualifiedClassName();
 
-        $toHandle = $fieldConfig['field']['to'];
+        $toHandle = $fieldConfig['field']['as'] ?? $fieldConfig['field']['to'];
         $selectedEntity = $sectionEntity->{'get' . ucfirst($toHandle)}();
 
         try {

--- a/test/unit/FieldType/Relationship/RelationshipTest.php
+++ b/test/unit/FieldType/Relationship/RelationshipTest.php
@@ -1,7 +1,7 @@
 <?php
 declare (strict_types=1);
 
-namespace Tardigrades\FieldType\Number;
+namespace Tardigrades\FieldType\Relationship;
 
 use PHPUnit\Framework\TestCase;
 use Mockery as M;
@@ -228,6 +228,95 @@ class RelationshipTest extends TestCase
      * @test
      * @covers ::addToForm
      */
+    public function it_adds_to_form_many_to_one_with_field_alias()
+    {
+        $relation = new Relationship();
+        $fieldConfig = FieldConfig::fromArray(
+            [
+                'field' =>
+                    [
+                        'name' => 'sexyname',
+                        'handle' => 'lovehandles',
+                        'kind' => 'many-to-one',
+                        'to' => 'neptune',
+                        'as' => 'somethingElse',
+                        'form' => ['all' => ['relations']],
+                        'variant' => 'not the variant you are looking for'
+                    ]
+            ]
+        );
+        $relation->setConfig($fieldConfig);
+
+        $this->sectionEntity->shouldReceive('getId')
+            ->once()
+            ->andReturn(9);
+
+        $sectionTo = M::mock(SectionInterface::class)->makePartial();
+
+        $this->sectionManager->shouldReceive('readByHandle')
+            ->once()
+            ->andReturn($sectionTo);
+
+        $sectionConfigTo = SectionConfig::fromArray(
+            [
+                'section' => [
+                    'name' => 'nameOfSection',
+                    'handle' => 'handleOfSection',
+                    'fields' => ['1', '2', '3'],
+                    'default' => 'sexyPerDefault',
+                    'namespace' => 'the space has no name'
+                ]
+            ]
+        );
+
+        $sectionTo->shouldReceive('getConfig')
+            ->once()
+            ->andReturn($sectionConfigTo);
+
+        $selectedEntity = M::mock('alias:selectedEntity')->makePartial();
+
+        $this->sectionEntity->shouldReceive('getSomethingElse')
+            ->once()
+            ->andReturn($selectedEntity);
+
+        $mockEntry = M::mock('alias:entry')->makePartial();
+        $mockEntry->shouldReceive('getDefault')
+            ->once()
+            ->andReturn('planetarySexyEntry');
+
+        $this->readSection->shouldReceive('read')
+            ->once()
+            ->andReturn(new \ArrayIterator([$mockEntry]));
+
+        $this->formBuilder->shouldReceive('add')
+            ->once()
+            ->with(
+                'somethingElse',
+                ChoiceType::class,
+                [
+                    'choices' => ['...' => null, 'planetarySexyEntry' => $mockEntry],
+                    'data' => $selectedEntity,
+                    'multiple' => false
+                ]
+            )
+            ->andReturn($this->formBuilder);
+
+        $relation->addToForm(
+            $this->formBuilder,
+            $this->section,
+            $this->sectionEntity,
+            $this->sectionManager,
+            $this->readSection
+        );
+
+        $this->assertInstanceOf(Relationship::class, $relation);
+        $this->assertEquals($relation->getConfig(), $fieldConfig);
+    }
+
+    /**
+     * @test
+     * @covers ::addToForm
+     */
     public function it_adds_to_form_many_to_many()
     {
         $relation = new Relationship();
@@ -383,6 +472,95 @@ class RelationshipTest extends TestCase
             ->once()
             ->with(
                 'neptune',
+                ChoiceType::class,
+                [
+                    'choices' => ['...' => null, 'planetarySexyEntry' => $mockEntry],
+                    'data' => $selectedEntity,
+                    'multiple' => false
+                ]
+            )
+            ->andReturn($this->formBuilder);
+
+        $relation->addToForm(
+            $this->formBuilder,
+            $this->section,
+            $this->sectionEntity,
+            $this->sectionManager,
+            $this->readSection
+        );
+
+        $this->assertInstanceOf(Relationship::class, $relation);
+        $this->assertEquals($relation->getConfig(), $fieldConfig);
+    }
+
+    /**
+     * @test
+     * @covers ::addToForm
+     */
+    public function it_adds_to_form_one_to_one_with_field_alias()
+    {
+        $relation = new Relationship();
+        $fieldConfig = FieldConfig::fromArray(
+            [
+                'field' =>
+                    [
+                        'name' => 'sexyname',
+                        'handle' => 'lovehandles',
+                        'kind' => 'one-to-one',
+                        'to' => 'neptune',
+                        'as' => 'somethingElse',
+                        'form' => ['all' => ['relations']],
+                        'variant' => 'not the variant you are looking for'
+                    ]
+            ]
+        );
+        $relation->setConfig($fieldConfig);
+
+        $this->sectionEntity->shouldReceive('getId')
+            ->once()
+            ->andReturn(9);
+
+        $sectionTo = M::mock(SectionInterface::class)->makePartial();
+
+        $this->sectionManager->shouldReceive('readByHandle')
+            ->once()
+            ->andReturn($sectionTo);
+
+        $sectionConfigTo = SectionConfig::fromArray(
+            [
+                'section' => [
+                    'name' => 'nameOfSection',
+                    'handle' => 'handleOfSection',
+                    'fields' => ['1', '2', '3'],
+                    'default' => 'sexyPerDefault',
+                    'namespace' => 'the space has no name'
+                ]
+            ]
+        );
+
+        $sectionTo->shouldReceive('getConfig')
+            ->once()
+            ->andReturn($sectionConfigTo);
+
+        $selectedEntity = M::mock('alias:selectedEntity')->makePartial();
+
+        $this->sectionEntity->shouldReceive('getSomethingElse')
+            ->once()
+            ->andReturn($selectedEntity);
+
+        $mockEntry = M::mock('alias:entry')->makePartial();
+        $mockEntry->shouldReceive('getDefault')
+            ->once()
+            ->andReturn('planetarySexyEntry');
+
+        $this->readSection->shouldReceive('read')
+            ->once()
+            ->andReturn(new \ArrayIterator([$mockEntry]));
+
+        $this->formBuilder->shouldReceive('add')
+            ->once()
+            ->with(
+                'somethingElse',
                 ChoiceType::class,
                 [
                     'choices' => ['...' => null, 'planetarySexyEntry' => $mockEntry],


### PR DESCRIPTION
When creating a single relationship to an entity, the toHandle is the name of the entity.
When creating multiple relationships to the same entity, multiple toHandles should be created with different names.
By using the 'as' field in de field config of many-to-one and one-to-one relationships this is made possible.